### PR TITLE
fix "Function name must be a string"

### DIFF
--- a/src/AzureStorageServiceProvider.php
+++ b/src/AzureStorageServiceProvider.php
@@ -19,7 +19,7 @@ class AzureStorageServiceProvider extends ServiceProvider
     {
         Storage::extend('azure', function ($app, $config) {
             $connectionString = sprintf('DefaultEndpointsProtocol=%s;AccountName=%s;AccountKey=%s;BlobEndpoint=%s',
-                isset($config['protocol']) ? $config('protocol') : 'https',
+                isset($config['protocol']) ? $config['protocol'] : 'https',
                 $config['account']['name'],
                 $config['account']['key'],
                 $config['blob-endpoint']


### PR DESCRIPTION
**Symfony\Component\Debug\Exception\FatalThrowableError**
`/vendor/futureoriented/laravel-flysystem-azure/src/AzureStorageServiceProvider.php22`
> Function name must be a string